### PR TITLE
Fix package recipes to download release sources

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,46 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+
+class MexceConan(ConanFile):
+    name = "mexce"
+    version = "1.0.0"
+    license = "BSD-2-Clause"
+    homepage = "https://github.com/imakris/mexce"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "Single-header, dependency-free JIT compiler for scalar mathematical expressions."
+    topics = ("jit", "math", "expression-parser", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        basic_layout(self)
+
+    def validate(self):
+        allowed_architectures = {"x86", "x86_64"}
+        if str(self.settings.arch) not in allowed_architectures:
+            raise ConanInvalidConfiguration(
+                "mexce only supports x86 and x86_64 architectures")
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self,
+            url=f"https://github.com/imakris/mexce/archive/refs/tags/v{self.version}.zip",
+            strip_root=True)
+
+    def package(self):
+        copy(self, "mexce.h", self.source_folder,
+             os.path.join(self.package_folder, "include"))
+        copy(self, "LICENSE*", self.source_folder,
+             os.path.join(self.package_folder, "licenses"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_file_name", "mexce")
+        self.cpp_info.set_property("cmake_target_name", "mexce::mexce")

--- a/ports/mexce/portfile.cmake
+++ b/ports/mexce/portfile.cmake
@@ -1,0 +1,14 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO imakris/mexce
+    REF "v${VERSION}"
+    SHA512 325fe93d7d1c49baabdfc522e7d37266a087bb0d33221e30a972f09aa5fc0bcfdcf8462676d85cd703c1a9c32d26b0c30ca4a68c5f250acb34272306e4b890b5
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/mexce.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/mexce/usage
+++ b/ports/mexce/usage
@@ -1,0 +1,5 @@
+Header-only library. After installing, include the header:
+
+    #include <mexce.h>
+
+The library targets x86/x86_64 architectures only.

--- a/ports/mexce/vcpkg.json
+++ b/ports/mexce/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "mexce",
+  "version": "1.0.0",
+  "description": "Header-only JIT compiler for scalar mathematical expressions.",
+  "homepage": "https://github.com/imakris/mexce",
+  "license": "BSD-2-Clause",
+  "supports": "(windows | linux) & !(arm | arm64)"
+}

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(mexce_test_package LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(mexce CONFIG REQUIRED)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE mexce::mexce)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,31 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.build import can_run
+import os
+
+
+class MexceTestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def run(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(cmd, env="conanrun")

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -1,0 +1,12 @@
+#include <mexce.h>
+#include <iostream>
+
+int main() {
+    mexce::evaluator eval;
+    double x = 0.5;
+    eval.bind(x, "x");
+    eval.set_expression("sin(x) + 1");
+    const double result = eval.evaluate();
+    std::cout << "Result: " << result << '\n';
+    return (result != 0.0) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- add a Conan recipe for the header-only mexce library that fetches the v1.0.0 release, enforces x86/x86_64 validation, and publishes CMake target metadata
- provide a Conan test package that builds a small executable via CMakeDeps/CMakeToolchain
- add a vcpkg overlay port that downloads the v1.0.0 release and installs the mexce header, license, and usage guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d6865c2fc8832dbe1b5188e47996d2