### PR TITLE
Adjust vcpkg supports architecture expression

### DIFF
--- a/ports/mexce/vcpkg.json
+++ b/ports/mexce/vcpkg.json
@@ -4,5 +4,5 @@
   "description": "Header-only JIT compiler for scalar mathematical expressions.",
   "homepage": "https://github.com/imakris/mexce",
   "license": "BSD-2-Clause",
-  "supports": "(windows | linux) & !(arm | arm64)"
+  "supports": "(windows | linux) & (x86 | x64)"
 }


### PR DESCRIPTION
## Summary
- update the mexce port definition to target x86 and x64 architectures on Windows and Linux

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68da47d74d14832d9a4ec13e7f630e17