### PR TITLE
Add adaptable wall clock helper

### DIFF
--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -11,7 +11,7 @@
 #  pragma warning(pop)
 #endif
 
-#include <omp.h>
+#include "get_wtime.h"
 
 #include <algorithm>
 #include <cmath>
@@ -399,10 +399,10 @@ int main(int argc, char* argv[])
             update_bin_counts(rec.ulp_compiler_vs_reference, exact_zero_count_comp_ref, bin_counts_comp_ref, comparisons_comp_ref);
         }
 
-        const double compile_start = omp_get_wtime();
+        const double compile_start = mexce::get_wtime();
         try {
             eval.set_expression(expr);
-            const double compile_end = omp_get_wtime();
+            const double compile_end = mexce::get_wtime();
             rec.compile_ns = (uint64_t)((compile_end - compile_start) * 1e9 + 0.5L);
             rec.compiled = true;
             ++compiled_count;
@@ -413,7 +413,7 @@ int main(int argc, char* argv[])
             compile_times.push_back(rec.compile_ns);
         }
         catch (const std::exception& e) {
-            const double compile_end = omp_get_wtime();
+            const double compile_end = mexce::get_wtime();
             rec.compile_ns = (uint64_t)((compile_end - compile_start) * 1e9 + 0.5L);
             ++compile_fail_count;
             rec.error = std::string("compile: ") + e.what();
@@ -453,12 +453,12 @@ int main(int argc, char* argv[])
             update_bin_counts(rec.ulp_mexce_vs_compiler, exact_zero_count_mexce_comp, bin_counts_mexce_comp, comparisons_mexce_comp);
         }
 
-        const double t0 = omp_get_wtime();
+        const double t0 = mexce::get_wtime();
         std::size_t executed = 0;
         for (; executed < (std::size_t)iterations; ++executed) {
             (void)eval.evaluate();
         }
-        const double t1 = omp_get_wtime();
+        const double t1 = mexce::get_wtime();
 
         rec.dur_ns = (long long)((t1 - t0) * 1e9);
         rec.avg_ns = (uint64_t)((long double)rec.dur_ns / (long double)executed + 0.5L);
@@ -468,12 +468,12 @@ int main(int argc, char* argv[])
         ++benchmarked_functions;
 
         if (rec.native_eval_ok) {
-            const double tn0 = omp_get_wtime();
+            const double tn0 = mexce::get_wtime();
             std::size_t native_executed = 0;
             for (; native_executed < (std::size_t)iterations; ++native_executed) {
                 (void)mexce::benchmark_data::kNativeExpressions[idx](native_ctx);
             }
-            const double tn1 = omp_get_wtime();
+            const double tn1 = mexce::get_wtime();
 
             rec.native_dur_ns = (long long)((tn1 - tn0) * 1e9);
             rec.native_avg_ns = (uint64_t)((long double)rec.native_dur_ns / (long double)native_executed + 0.5L);

--- a/test/get_wtime.h
+++ b/test/get_wtime.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <chrono>
+#include <limits>
+
+#ifdef _OPENMP
+#  include <omp.h>
+#endif
+
+namespace mexce {
+namespace detail {
+
+inline double chrono_resolution_seconds() noexcept
+{
+    typedef std::chrono::steady_clock clock;
+    typedef clock::period period;
+    return static_cast<double>(period::num) / static_cast<double>(period::den);
+}
+
+inline double chrono_now_seconds() noexcept
+{
+    typedef std::chrono::steady_clock clock;
+    const clock::time_point now = clock::now();
+    const std::chrono::duration<double> seconds = now.time_since_epoch();
+    return seconds.count();
+}
+
+inline double omp_resolution_seconds() noexcept
+{
+#ifdef _OPENMP
+    const double tick = omp_get_wtick();
+    return (tick > 0.0) ? tick : std::numeric_limits<double>::infinity();
+#else
+    return std::numeric_limits<double>::infinity();
+#endif
+}
+
+inline bool should_use_chrono() noexcept
+{
+    const double chrono_res = chrono_resolution_seconds();
+    const double omp_res = omp_resolution_seconds();
+    if (!(chrono_res > 0.0)) {
+        return false;
+    }
+    return chrono_res < omp_res;
+}
+
+} // namespace detail
+
+inline double get_wtime() noexcept
+{
+    static const bool use_chrono = detail::should_use_chrono();
+#ifdef _OPENMP
+    if (!use_chrono) {
+        return omp_get_wtime();
+    }
+#endif
+    return detail::chrono_now_seconds();
+}
+
+} // namespace mexce
+


### PR DESCRIPTION
## Summary
- add a mexce::get_wtime helper that wraps omp_get_wtime and falls back to std::chrono when it provides finer granularity
- update the benchmark to use the new helper so timing remains in doubles while benefiting from higher-resolution clocks when needed

## Testing
- cmake --build build --target benchmark
- ./build/benchmark

------
https://chatgpt.com/codex/tasks/task_b_68daaa5bde98832da6322235909d1c1c