### PR TITLE
Expand unit test coverage for parsing and optimizers

### DIFF
--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -2,9 +2,13 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
+#include <functional>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -34,6 +38,25 @@ struct TestSuite {
     void expect_true(const std::string& name, bool value) {
         if (!value) {
             failures.push_back(name + " failed");
+        }
+    }
+
+    template <typename Exception, typename Func>
+    void expect_throw(const std::string& name, Func&& func, const std::string& expected_message = std::string()) {
+        try {
+            func();
+            failures.push_back(name + " failed: expected exception");
+        }
+        catch (const Exception& ex) {
+            if (!expected_message.empty() && expected_message != ex.what()) {
+                std::ostringstream oss;
+                oss << name << " failed: expected message \"" << expected_message
+                    << "\", got \"" << ex.what() << "\"";
+                failures.push_back(oss.str());
+            }
+        }
+        catch (...) {
+            failures.push_back(name + " failed: unexpected exception type");
         }
     }
 };
@@ -219,6 +242,213 @@ void test_constants_and_single_shot(TestSuite& suite) {
     suite.expect_near("trig", eval.evaluate(), std::sin(x) + std::cos(y));
 }
 
+void test_pow_optimizer_special_cases(TestSuite& suite) {
+    mexce::evaluator eval;
+    double x = 9.0;
+    eval.bind(x, "x");
+
+    eval.set_expression("pow(x, 0.5)");
+    suite.expect_near("pow_optimizer_sqrt", eval.evaluate(), std::sqrt(x));
+
+    x = 16.0;
+    eval.set_expression("pow(x, 0)");
+    suite.expect_near("pow_optimizer_zero_exponent", eval.evaluate(), 1.0);
+
+    x = 5.0;
+    eval.set_expression("pow(x, 1)");
+    suite.expect_near("pow_optimizer_exponent_one", eval.evaluate(), x);
+
+    x = 2.0;
+    eval.set_expression("pow(x, 3.3)");
+    suite.expect_near("pow_optimizer_generic_path", eval.evaluate(), std::pow(x, 3.3));
+}
+
+void test_helper_functions_and_element(TestSuite& suite) {
+    using namespace mexce::impl;
+
+    suite.expect_true("function_name_to_infix_operator_add", function_name_to_infix_operator("add") == "+");
+    suite.expect_true("function_name_to_infix_operator_unknown", function_name_to_infix_operator("noop").empty());
+    suite.expect_true("function_name_to_unary_operator_neg", function_name_to_unary_operator("neg") == "-");
+    suite.expect_true("function_name_to_unary_operator_unknown", function_name_to_unary_operator("noop").empty());
+    suite.expect_true("double_to_pretty_string", double_to_pretty_string(3.25) == "3.25");
+
+    Element default_element;
+    suite.expect_true("element_default_type", default_element.type == Element_type::CCONST);
+    suite.expect_true("element_default_id", default_element.id == 0);
+
+    double value = 4.0;
+    auto variable = std::make_shared<Variable>(1, &value, "value", M32FP);
+    auto constant = std::make_shared<Constant>(2, 3.0);
+    auto add_function = std::make_shared<Function>(3, "add", 2, 0, 0, nullptr);
+
+    elist_t elist;
+    elist.push_back(Element(variable));
+    elist.push_back(Element(constant));
+    elist.push_back(Element(add_function));
+
+    std::string elist_string = elist_to_string(elist);
+    suite.expect_true("elist_to_string", elist_string == "(value+3)");
+
+    suite.expect_true("get_ndt_float", get_ndt<float>() == M32FP);
+    suite.expect_true("get_ndt_int16", get_ndt<int16_t>() == M16INT);
+    suite.expect_true("get_ndt_int32", get_ndt<int32_t>() == M32INT);
+    suite.expect_true("get_ndt_int64", get_ndt<int64_t>() == M64INT);
+}
+
+void test_binding_and_unbinding(TestSuite& suite) {
+    mexce::evaluator eval;
+
+    double x = 1.0;
+    float f = 2.0f;
+    int16_t i16 = 3;
+    int32_t i32 = 4;
+    int64_t i64 = 5;
+
+    eval.bind(x, "x", f, "f", i16, "i16", i32, "i32", i64, "i64");
+
+    eval.set_expression("x + f + i16 + i32 + i64");
+    double expected = x + f + i16 + i32 + static_cast<double>(i64);
+    suite.expect_near("multi_type_binding", eval.evaluate(), expected);
+
+    eval.unbind_all();
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("unbind_all_removes_variables", [&] {
+        eval.set_expression("x");
+    }, "x is not a known constant, variable or function name");
+
+    mexce::evaluator function_conflict;
+    suite.expect_throw<std::logic_error>("bind_conflict_function", [&] {
+        double y = 1.0;
+        function_conflict.bind(y, "add");
+    }, "Attempted to bind a variable, named as an existing function");
+
+    mexce::evaluator constant_conflict;
+    suite.expect_throw<std::logic_error>("bind_conflict_constant", [&] {
+        double y = 1.0;
+        constant_conflict.bind(y, "pi");
+    }, "Attempted to bind a variable, named as an existing constant");
+}
+
+void test_mexce_parsing_exception_class(TestSuite& suite) {
+    mexce::mexce_parsing_exception ex("custom message", 3);
+    suite.expect_true("mexce_parsing_exception_message", std::string(ex.what()) == "custom message");
+}
+
+void test_memory_management(TestSuite& suite) {
+    size_t size = 4096;
+    uint8_t* buffer = mexce::impl::get_executable_buffer(size);
+    suite.expect_true("get_executable_buffer", buffer != nullptr);
+    mexce::impl::free_executable_buffer(reinterpret_cast<double(*)()>(buffer), size);
+}
+
+void test_asmd_optimizer_branches(TestSuite& suite) {
+    mexce::evaluator eval;
+    float a = 2.0f;
+    float b = 3.0f;
+    eval.bind(a, "a", b, "b");
+
+    eval.set_expression("a + b + 5");
+    suite.expect_near("asmd_optimizer_add_constants", eval.evaluate(), a + b + 5.0);
+
+    eval.set_expression("a * b * 2");
+    suite.expect_near("asmd_optimizer_mul_constants", eval.evaluate(), a * b * 2.0);
+}
+
+void test_parsing_errors(TestSuite& suite) {
+    suite.expect_throw<std::logic_error>("empty_expression", [] {
+        mexce::evaluator().set_expression("");
+    }, "Expected an expression");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("leading_closing_parenthesis", [] {
+        mexce::evaluator().set_expression(")");
+    }, "Expected a \")\"");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("unexpected_symbol_at_start", [] {
+        mexce::evaluator().set_expression("@");
+    }, "\"@\" not expected");
+
+    {
+        mexce::evaluator eval;
+        eval.set_expression(".5");
+        suite.expect_near("leading_decimal_literal", eval.evaluate(), 0.5);
+    }
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("invalid_numeric_suffix", [] {
+        mexce::evaluator().set_expression("1a");
+    }, "\"a\" not expected");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("closing_paren_after_number", [] {
+        mexce::evaluator().set_expression("1)");
+    }, "\")\" not expected");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("missing_function_argument", [] {
+        mexce::evaluator().set_expression("min(1)");
+    }, "Expected more arguments");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("comma_requires_closing_paren_numeric", [] {
+        mexce::evaluator().set_expression("(1,2)");
+    }, "Expected a \")\"");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("too_many_function_arguments", [] {
+        mexce::evaluator().set_expression("min(1,2,3)");
+    }, "Don't expect any arguments here");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("numeric_exponent_missing_sign", [] {
+        mexce::evaluator().set_expression("1e)");
+    }, "expecting '+'/'-' followed by the exponent of the numeric literal");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("numeric_exponent_missing_digits", [] {
+        mexce::evaluator().set_expression("1e+x");
+    }, "expecting the exponent of the numeric literal");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("unknown_identifier", [] {
+        mexce::evaluator().set_expression("foo ");
+    }, "foo is not a known constant, variable or function name");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("unknown_identifier_before_paren", [] {
+        mexce::evaluator().set_expression("foo)");
+    }, "foo is not a known constant or variable name");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("unknown_function_name", [] {
+        mexce::evaluator().set_expression("foo(");
+    }, "foo is not a known function name");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("unknown_identifier_before_operator", [] {
+        mexce::evaluator().set_expression("foo+");
+    }, "foo is not a known constant or variable name");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("unknown_identifier_before_comma", [] {
+        mexce::evaluator().set_expression("foo,");
+    }, "foo is not a known constant or variable name");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("unexpected_symbol_after_identifier", [] {
+        mexce::evaluator().set_expression("foo@");
+    }, "\"@\" not expected");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("missing_open_paren_before_comma", [] {
+        mexce::evaluator eval;
+        double foo = 1.0;
+        eval.bind(foo, "foo");
+        eval.set_expression("(foo,1)");
+    }, "Expected a \")\"");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("function_comma_too_many", [] {
+        mexce::evaluator().set_expression("min(1,2,)");
+    }, "Don't expect any arguments here");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("expected_function_parenthesis", [] {
+        mexce::evaluator().set_expression("sin 1");
+    }, "Expected a \"(\"");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("unclosed_parenthesis", [] {
+        mexce::evaluator().set_expression("(");
+    }, "Expected a \")\"");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("unexpected_end_of_expression", [] {
+        mexce::evaluator().set_expression("1+");
+    }, "Unexpected end of expression");
+}
+
 } // namespace
 
 int main() {
@@ -231,6 +461,13 @@ int main() {
     test_rounding_functions(suite);
     test_min_max_and_arithmetic(suite);
     test_constants_and_single_shot(suite);
+    test_pow_optimizer_special_cases(suite);
+    test_helper_functions_and_element(suite);
+    test_binding_and_unbinding(suite);
+    test_mexce_parsing_exception_class(suite);
+    test_memory_management(suite);
+    test_asmd_optimizer_branches(suite);
+    test_parsing_errors(suite);
 
     if (!suite.failures.empty()) {
         std::cerr << "mexce unit tests failed (" << suite.failures.size() << ")" << std::endl;


### PR DESCRIPTION
## Summary
- add an exception-check helper and extensive parsing failure tests to raise coverage
- cover pow/asmd optimizer scenarios, helper utilities, and numeric data type mappings
- exercise the default element, pretty-print helpers, and executable buffer cleanup

## Testing
- g++ -std=c++17 test/unit_tests.cpp -I. -o unit_tests
- ./unit_tests

------
https://chatgpt.com/codex/tasks/task_b_68dc12a30c30832db757b3a16f19302e