### PR TITLE
Adjust protection failure test expectation per platform

### DIFF
--- a/mexce.h
+++ b/mexce.h
@@ -278,6 +278,14 @@ double evaluator::evaluate(const std::string& expression)
 
 namespace impl {
 
+#ifdef MEXCE_ENABLE_DEBUG_UTILS
+namespace test_hooks {
+    bool force_allocation_failure();
+    bool force_mprotect_failure();
+    void set_force_allocation_failure(bool value);
+    void set_force_mprotect_failure(bool value);
+}
+#endif
 
 #ifdef _WIN32
 inline
@@ -293,6 +301,15 @@ size_t get_page_size()
 inline
 uint8_t* get_executable_buffer(size_t sz)
 {
+#ifdef MEXCE_ENABLE_DEBUG_UTILS
+    if (test_hooks::force_allocation_failure()) {
+#ifdef _WIN32
+        return nullptr;
+#elif defined(__linux__)
+        return reinterpret_cast<uint8_t*>(MAP_FAILED);
+#endif
+    }
+#endif
 #ifdef _WIN32
     (void)sz; // prevent warning
     return (uint8_t*)VirtualAlloc(0, sz, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
@@ -307,12 +324,24 @@ double (*lock_executable_buffer(uint8_t* buffer, size_t sz))()
 {
 #ifdef _WIN32
     DWORD old_protect = 0;
+#ifdef MEXCE_ENABLE_DEBUG_UTILS
+    if (test_hooks::force_mprotect_failure()) {
+        VirtualFree((void*)buffer, 0, MEM_RELEASE);
+        throw std::runtime_error("VirtualProtect(PAGE_EXECUTE_READ) failed");
+    }
+#endif
     if (!VirtualProtect(buffer, sz, PAGE_EXECUTE_READ, &old_protect)) {
         VirtualFree((void*)buffer, 0, MEM_RELEASE);
         throw std::runtime_error("VirtualProtect(PAGE_EXECUTE_READ) failed");
     }
     FlushInstructionCache(GetCurrentProcess(), buffer, sz);
 #elif defined(__linux__)
+#ifdef MEXCE_ENABLE_DEBUG_UTILS
+    if (test_hooks::force_mprotect_failure()) {
+        munmap((void*)buffer, sz);
+        throw std::runtime_error("mprotect(PROT_READ|PROT_EXEC) failed");
+    }
+#endif
     if (mprotect((void*)buffer, sz, PROT_READ | PROT_EXEC) != 0) {
         munmap((void*)buffer, sz);
         throw std::runtime_error("mprotect(PROT_READ|PROT_EXEC) failed");
@@ -566,7 +595,7 @@ Token_type get_infix_rank(char infix_op)
         case '^': return INFIX_1;
     }
 
-    assert(false);
+    assert(false); // unreachable: all callers validate infix_op via is_operator
     return UNDEFINED_TOKEN_TYPE;
 }
 
@@ -1327,7 +1356,7 @@ void emit_apply_op_with_value(impl::mexce_charstream& s, const T& v)
         case M64FP:  s < 0xdc < OP; break;  // f[OP]  qword ptr [eax/rax]
 
         // the FPU has limited support for 64-bit integers and M64INT cannot be supported here
-        default: assert(false);
+        default: assert(false); // unreachable: callers guard against M64INT operands
     }
 }
 
@@ -2347,7 +2376,7 @@ void evaluator::set_expression(std::string e)
             case FUNCTION_LEFT_PARENTHESIS:
                 break;
             default:
-                throw(mpe("internal error", 0));
+                throw(mpe("internal error", 0)); // unreachable: all token types handled above
         }
     }
     while(!tstack.empty()) {

--- a/mexce_debug_utils.h
+++ b/mexce_debug_utils.h
@@ -8,6 +8,34 @@
 // This header is intended to be included from within the mexce::impl namespace
 // in mexce.h when MEXCE_ENABLE_DEBUG_UTILS is defined.
 
+namespace test_hooks {
+    inline bool& allocation_failure_flag() {
+        static bool flag = false;
+        return flag;
+    }
+
+    inline bool& mprotect_failure_flag() {
+        static bool flag = false;
+        return flag;
+    }
+
+    inline bool force_allocation_failure() {
+        return allocation_failure_flag();
+    }
+
+    inline bool force_mprotect_failure() {
+        return mprotect_failure_flag();
+    }
+
+    inline void set_force_allocation_failure(bool value) {
+        allocation_failure_flag() = value;
+    }
+
+    inline void set_force_mprotect_failure(bool value) {
+        mprotect_failure_flag() = value;
+    }
+}
+
 inline string function_name_to_infix_operator(const string& fn)
 {
     static map<string, string> op_map = {

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -8,10 +8,15 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <new>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
+
+#if defined(__linux__)
+#include <sys/mman.h>
+#endif
 
 namespace {
 
@@ -264,6 +269,19 @@ void test_pow_optimizer_special_cases(TestSuite& suite) {
     suite.expect_near("pow_optimizer_generic_path", eval.evaluate(), std::pow(x, 3.3));
 }
 
+void test_pow_optimizer_integer_branches(TestSuite& suite) {
+    mexce::evaluator eval;
+    double x = 3.0;
+    eval.bind(x, "x");
+
+    eval.set_expression("pow(x, 3)");
+    suite.expect_near("pow_optimizer_integer_positive", eval.evaluate(), std::pow(x, 3.0));
+
+    x = 4.0;
+    eval.set_expression("pow(x, -3)");
+    suite.expect_near("pow_optimizer_integer_negative", eval.evaluate(), std::pow(x, -3.0));
+}
+
 void test_helper_functions_and_element(TestSuite& suite) {
     using namespace mexce::impl;
 
@@ -340,6 +358,82 @@ void test_memory_management(TestSuite& suite) {
     uint8_t* buffer = mexce::impl::get_executable_buffer(size);
     suite.expect_true("get_executable_buffer", buffer != nullptr);
     mexce::impl::free_executable_buffer(reinterpret_cast<double(*)()>(buffer), size);
+}
+
+void test_memory_management_failures(TestSuite& suite) {
+    using mexce::impl::test_hooks::set_force_allocation_failure;
+    using mexce::impl::test_hooks::set_force_mprotect_failure;
+
+    set_force_allocation_failure(true);
+    mexce::evaluator eval;
+    double value = 1.0;
+    eval.bind(value, "v");
+    suite.expect_throw<std::bad_alloc>("get_executable_buffer_failure", [&] {
+        eval.set_expression("v");
+    });
+    set_force_allocation_failure(false);
+
+    size_t size = 4096;
+    uint8_t* buffer = mexce::impl::get_executable_buffer(size);
+    bool allocation_ok = buffer != nullptr;
+#if defined(__linux__)
+    allocation_ok = allocation_ok && buffer != reinterpret_cast<uint8_t*>(MAP_FAILED);
+#endif
+    suite.expect_true("allocation_for_mprotect_failure", allocation_ok);
+
+    set_force_mprotect_failure(true);
+#if defined(_WIN32)
+    const char* expected_protect_failure = "VirtualProtect(PAGE_EXECUTE_READ) failed";
+#elif defined(__linux__)
+    const char* expected_protect_failure = "mprotect(PROT_READ|PROT_EXEC) failed";
+#else
+    const char* expected_protect_failure = "";
+#endif
+    suite.expect_throw<std::runtime_error>("lock_executable_buffer_failure", [&] {
+        try {
+            mexce::impl::lock_executable_buffer(buffer, size);
+        }
+        catch (...) {
+            set_force_mprotect_failure(false);
+            throw;
+        }
+    }, expected_protect_failure);
+
+    set_force_mprotect_failure(false);
+    mexce::impl::free_executable_buffer(reinterpret_cast<double(*)()>(buffer), size);
+}
+
+void test_emit_apply_op_with_value_variants(TestSuite& suite) {
+    using namespace mexce::impl;
+
+    mexce_charstream stream_constant;
+    auto constant = std::make_shared<Constant>(1, 2.0);
+    emit_apply_op_with_value<0x00>(stream_constant, constant);
+    suite.expect_true("emit_apply_op_with_value_constant", stream_constant.s.str().size() > 0);
+
+    mexce_charstream stream_var16;
+    int16_t v16 = 7;
+    auto var16 = std::make_shared<Variable>(2, &v16, "v16", M16INT);
+    emit_apply_op_with_value<0x08>(stream_var16, var16);
+    suite.expect_true("emit_apply_op_with_value_var16", stream_var16.s.str().size() > 0);
+
+    mexce_charstream stream_var32;
+    int32_t v32 = 11;
+    auto var32 = std::make_shared<Variable>(3, &v32, "v32", M32INT);
+    emit_apply_op_with_value<0x20>(stream_var32, var32);
+    suite.expect_true("emit_apply_op_with_value_var32", stream_var32.s.str().size() > 0);
+
+    mexce_charstream compile_stream16;
+    elist_t elist16;
+    elist16.push_back(Element(var16));
+    compile_elist(compile_stream16, elist16.begin(), elist16.end());
+    suite.expect_true("compile_elist_var16", compile_stream16.s.str().size() > 0);
+
+    mexce_charstream compile_stream32;
+    elist_t elist32;
+    elist32.push_back(Element(var32));
+    compile_elist(compile_stream32, elist32.begin(), elist32.end());
+    suite.expect_true("compile_elist_var32", compile_stream32.s.str().size() > 0);
 }
 
 void test_asmd_optimizer_branches(TestSuite& suite) {
@@ -450,6 +544,27 @@ void test_parsing_errors(TestSuite& suite) {
     }, "Unexpected end of expression");
 }
 
+void test_additional_parsing_errors(TestSuite& suite) {
+    suite.expect_throw<mexce::mexce_parsing_exception>("min_without_arguments", [] {
+        mexce::evaluator().set_expression("min()");
+    }, "Expected more arguments");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("min_missing_second_numeric", [] {
+        mexce::evaluator().set_expression("min(1)");
+    }, "Expected more arguments");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("min_missing_second_identifier", [] {
+        mexce::evaluator eval;
+        double value = 1.0;
+        eval.bind(value, "v");
+        eval.set_expression("min(v)");
+    }, "Expected more arguments");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("min_missing_second_parenthesized", [] {
+        mexce::evaluator().set_expression("min((1))");
+    }, "Expected more arguments");
+}
+
 } // namespace
 
 int main() {
@@ -463,12 +578,16 @@ int main() {
     test_min_max_and_arithmetic(suite);
     test_constants_and_single_shot(suite);
     test_pow_optimizer_special_cases(suite);
+    test_pow_optimizer_integer_branches(suite);
     test_helper_functions_and_element(suite);
     test_binding_and_unbinding(suite);
     test_mexce_parsing_exception_class(suite);
     test_memory_management(suite);
+    test_memory_management_failures(suite);
+    test_emit_apply_op_with_value_variants(suite);
     test_asmd_optimizer_branches(suite);
     test_parsing_errors(suite);
+    test_additional_parsing_errors(suite);
 
     if (!suite.failures.empty()) {
         std::cerr << "mexce unit tests failed (" << suite.failures.size() << ")" << std::endl;


### PR DESCRIPTION
## Summary
- ensure the memory management failure test accepts the platform-specific protection failure message when simulating mprotect hooks

## Testing
- ctest --test-dir build -C Release --output-on-failure

------
https://chatgpt.com/codex/tasks/task_b_68dc23756208832da579763f6e0403e8