### PR TITLE
Guard executable buffer locking against zero size

### DIFF
--- a/mexce.h
+++ b/mexce.h
@@ -305,6 +305,9 @@ uint8_t* get_executable_buffer(size_t sz)
 inline
 double (*lock_executable_buffer(uint8_t* buffer, size_t sz))()
 {
+    if (sz == 0) {
+        throw std::runtime_error("lock_executable_buffer requires a non-zero size");
+    }
 #ifdef _WIN32
     DWORD old_protect = 0;
     if (!VirtualProtect(buffer, sz, PAGE_EXECUTE_READ, &old_protect)) {


### PR DESCRIPTION
## Summary
- throw a runtime_error when attempting to lock an executable buffer with zero size to match the expected failure behavior

## Testing
- ctest --test-dir build (unit tests pass; benchmark targets not built in this run)


------
https://chatgpt.com/codex/tasks/task_b_68dcc45622fc832d8330b6a9f59a256c