### PR TITLE
Update comparison operator documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Compiles and executes an expression for a single use without replacing the defau
     | 1 (highest) | `^` | `pow` | Power / Exponentiation |
     | 2 | `*`, `/` | `mul`, `div` | Multiplication, Division |
     | 3 | `+`, `-` | `add`, `sub` | Addition, Subtraction |
-    | 4 (lowest) | `<` | `less_than`| Less-than comparison |
+    | 4 (lowest) | `<`, `>` | — | Less-than and greater-than comparison |
 *   **Unary Operators:** Unary `+` and `-` are supported.
-*   **Comparison:** The `<` operator returns a `double` (`1.0` if true, `0.0` if false).
+*   **Comparison:** The `<` and `>` operators return a `double` (`1.0` if true, `0.0` if false).
 
 ## Built-in Identifiers
 
@@ -126,7 +126,6 @@ Compiles and executes an expression for a single use without replacing the defau
 | `logb(base, value)` | Logarithm with a custom base. |
 | `ylog2(y, x)` | Computes `y * log2(x)`. |
 | `ceil(x)`, `floor(x)`, `round(x)`, `int(x)` | Rounding functions. |
-| `less_than(a, b)` | Returns `1.0` if `a < b`, else `0.0`. |
 | `sign(x)` | Returns `-1.0` for negative `x`, `1.0` otherwise. |
 | `signp(x)` | Returns `1.0` for positive `x`, `0.0` otherwise. |
 | `bnd(x, period)` | Wraps `x` to the interval `[0, period)`. |

--- a/mexce.h
+++ b/mexce.h
@@ -60,8 +60,8 @@
  * * Numeric literals may be written with decimal points or scientific
  *   notation.
  * * Unary `+` and `-` as well as the infix operators `+`, `-`, `*`, `/`, `^`
- *   (power) and `<` (less-than) are supported.  The `<` operator expands to the
- *   `lt(a, b)` function, yielding `1` when `a < b` and `0` otherwise.
+ *   (power) and the comparison operators `<` and `>` are supported.  Both yield
+ *   `1` when the comparison is true and `0` otherwise.
  * * Parentheses and comma-separated argument lists follow familiar C-like
  *   rules.
  *
@@ -84,7 +84,6 @@
  *   - `exp(x)` and `pow(a, b)` — base-e exponent and exponentiation.
  *   - `expn(x)` — exponent part of `x`, and `sfc(x)` — significand/fractional
  *     component of `x` in the range `[0.5, 1)`.
- *   - `lt(a, b)` — comparison used for the `<` operator.
  *   - `log(x)`/`ln(x)`, `log2(x)`, `log10(x)`, `logb(base, value)` and
  *     `ylog2(y, x)` (`y * log2(x)`).
  *   - `max(a, b)`, `min(a, b)` and `mod(a, b)`.


### PR DESCRIPTION
## Summary
- document the `<` and `>` operators in the README comparison table and description
- remove references to the comparison helper function from the public header comments to avoid documenting equality-style helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dcd1f0179c832db644b147c9d7c382