### PR TITLE
Add coverage tests for 16-bit and 32-bit variable loads

### DIFF
--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -320,6 +320,12 @@ void test_binding_and_unbinding(TestSuite& suite) {
     double expected = x + f + i16 + i32 + static_cast<double>(i64);
     suite.expect_near("multi_type_binding", eval.evaluate(), expected);
 
+    eval.set_expression("i16");
+    suite.expect_near("direct_int16_binding", eval.evaluate(), static_cast<double>(i16));
+
+    eval.set_expression("i32");
+    suite.expect_near("direct_int32_binding", eval.evaluate(), static_cast<double>(i32));
+
     eval.unbind_all();
 
     suite.expect_throw<mexce::mexce_parsing_exception>("unbind_all_removes_variables", [&] {


### PR DESCRIPTION
## Summary
- extend the binding tests to evaluate standalone int16_t and int32_t variables
- ensure the variable-loading instructions for 16-bit and 32-bit integers are exercised

## Testing
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_b_68dcd45e5ca0832d809fd36f849fcc08