### PR TITLE
Add unit tests for parser errors on unknown identifiers

### DIFF
--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -418,6 +418,22 @@ void test_parsing_errors(TestSuite& suite) {
         mexce::evaluator().set_expression("1a");
     }, "\"a\" not expected");
 
+    suite.expect_throw<mexce::mexce_parsing_exception>("unknown_identifier_before_closing_paren", [] {
+        mexce::evaluator().set_expression("(foo)");
+    }, "foo is not a known constant or variable name");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("unknown_identifier_before_operator", [] {
+        mexce::evaluator().set_expression("bar+1");
+    }, "bar is not a known constant or variable name");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("unknown_identifier_before_comma", [] {
+        mexce::evaluator().set_expression("min(foo,1)");
+    }, "foo is not a known constant or variable name");
+
+    suite.expect_throw<mexce::mexce_parsing_exception>("unknown_function_name", [] {
+        mexce::evaluator().set_expression("baz(1)");
+    }, "baz is not a known function name");
+
     suite.expect_throw<mexce::mexce_parsing_exception>("closing_paren_after_number", [] {
         mexce::evaluator().set_expression("1)");
     }, "\")\" not expected");


### PR DESCRIPTION
## Summary
- extend parser error unit tests to cover unknown identifiers before operators, commas, and closing parentheses
- verify that calling an unregistered function name triggers the correct parsing exception

## Testing
- ./build/unit_tests

------
https://chatgpt.com/codex/tasks/task_b_68dcd6309c2c832d8f108bca62abf498