### PR TITLE
Add pow optimizer unit test covering diff-low branch

### DIFF
--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -270,6 +270,10 @@ void test_pow_optimizer_special_cases(TestSuite& suite) {
     x = 2.0;
     eval.set_expression("pow(x, 3.3)");
     suite.expect_near("pow_optimizer_generic_path", eval.evaluate(), std::pow(x, 3.3));
+
+    x = 3.0;
+    eval.set_expression("pow(x, 7)");
+    suite.expect_near("pow_optimizer_diff_low_branch", eval.evaluate(), std::pow(x, 7.0));
 }
 
 void test_helper_functions_and_element(TestSuite& suite) {


### PR DESCRIPTION
## Summary
- add a pow optimizer unit test that exercises the diff_low branch for integer exponents
- verify the optimized evaluation matches std::pow for exponent seven

## Testing
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_b_68dce7bf0dac832da32b7bae10676013